### PR TITLE
[1주차] / [조민우]

### DIFF
--- a/조민우/1주차/[BOJ] 1018.py
+++ b/조민우/1주차/[BOJ] 1018.py
@@ -1,0 +1,15 @@
+n, m = map(int, input().split())
+board = [list(input()) for _ in range(n)]
+def find():
+    sum = 64
+    for k in range(n-7):
+        for l in range(m - 7):
+            temp = 0
+            for i in range(k, k+8):
+                for j in range(l, l+8):
+                    if (((i + j) % 2 == 0 and board[i][j] == 'B') or ((i + j) % 2 == 1 and board[i][j] == 'W')):
+                        temp += 1
+            temp = min(temp, 64 - temp)
+            sum = min(temp, sum)
+    return min(sum, 64-sum)
+print(find())

--- a/조민우/1주차/[BOJ] 9663.py
+++ b/조민우/1주차/[BOJ] 9663.py
@@ -1,0 +1,19 @@
+n = int(input())
+board = [0] * (n+1)
+count = 0
+def check(cnt):
+    for i in range(1, cnt):
+        if (board[cnt] == board[i] or abs(board[cnt] - board[i]) == cnt - i):
+            return False
+    return True
+def find(cnt):
+    if (cnt == n+1):
+        global count
+        count += 1
+        return
+    for i in range(1, n+1):
+        board[cnt] = i
+        if (check(cnt)):
+            find(cnt + 1)
+find(1)
+print(count)

--- a/조민우/1주차/[PRGMS] 42842.py
+++ b/조민우/1주차/[PRGMS] 42842.py
@@ -1,0 +1,11 @@
+def solution(brown, yellow):
+    answer = []
+    root = int(yellow**(1/2))
+    num = 1
+    for i in range(1, root+1):
+        if (yellow%i == 0):
+            num = yellow // i
+            if ((num+2) * (i + 2) - yellow == brown):
+                answer.append(num+2)
+                answer.append(i+2)
+                return answer


### PR DESCRIPTION
# 문제 풀이 / 알고리즘 분류

- [BOJ] 1018
  - 브루트포스(완전탐색)을 이용하여 문제 해결
  - 최소 8*8인 체스 판 중 8*8로 잘라서 최소한으로 색을 칠하는 경우에서의 횟수를 구하는 문제인데, (0,0)부터 (n-8, m-8)까지의 판을 8 * 8인 보드판으로 취급하여 4중 반복문을 이용해 문제를 풀었다.
  - 처음 색이 W로 시작하든 B로 시작하든 하나를 잡고 횟수를 구하여, 그 횟수와 색의 최대갯수 - 횟수 중 더 작은 값을 채택하여 최솟값을 갱신해주었다.
  - 실행시간을 줄이기 위해 생각해본 결과, 위 문제는 브루트포스가 아닌 DP를 이용하여 풀면 더욱 시간단축을 할 수 있을 것이라 생각했다.
    - 전체 판에 대해 DP를 사용하여 각 좌표에 대한 처음부터 좌표까지의 최소 횟수를 기입한다
      - 색을 바꿔야 할 경우 : DP[i][j] = DP[i-1][j] + DP[i][j-1] - DP[i-1][j-1] + 1
      - 아닐 경우 : DP[i][j] = DP[i-1][j] + DP[i][j-1] - DP[i-1][j-1]
    - 8칸씩 자르면서 DP최솟값을 구한다
      - min = DP[i][j] - DP[i-8][j] - DP[i][j-8] + DP[i-8][j-8]
    - min값과 64-min값 중 작은 값을 최솟값으로 갱신하여 값을 구할 수 있다

- [BOJ] 9663
  - 브루트포스(완전탐색) 중 백트래킹을 이용하여 문제 해결
  - 입력받은 정수만큼 재귀를 돌고, 정답을 찾을 경우 count에 1을 더해주는 방법으로 정답을 찾았다
  - 입력받은 정수만큼의 1차원 배열을 만들고(각 인덱스는 열을 의미) 그 안에 값을 넣어(행을 의미) 알맞은 결과를 도출하도록 했다
  - 퀸이 있을 수 없는 칸일 경우(같은 행에 있거나, 대각선 상에 있거나)는 재귀할 수 없도록 조건을 주었다
  - 시간을 더 줄이기 위해서는 방문했던 행을 체크해주면 된다
    - 본인은 2중 반복문을 사용하여 전의 값들과 넣을 값을 비교해줬는데, 브루트포스로 해결안할거면 visit배열을 만들고 방문안한 행만 바로 찾을 수 있도록 해주면 된다
- [PRGMS] 42842
  - 브루트포스(완전탐색)을 이용하여 문제 해결
  - 연산을 줄이기 위해 먼저 노란색 타일 갯수의 제곱근을 정수형으로 저장하고 1부터 제곱근 까지 완전탐색을 하며 약수를 찾았다
  - 약수를 찾았을 경우 노란색의 가로둘레+2 * 노란색의 세로둘레+2 가 갈색의 갯수일 경우 바로 반환해줘서 결과를 도출해냈다
  - 더 빠른 연산, 더 좋은 풀이는 뭐가 있는지 생각이 안났다

# 이슈 & 질문

