### PR TITLE
[1주차] / [민장규]

### DIFF
--- a/민장규/1주차/[BOJ] 1018.py
+++ b/민장규/1주차/[BOJ] 1018.py
@@ -1,0 +1,25 @@
+r, c = map(int, input().split())
+arr = [list(input()) for _ in range(r)]
+
+def reverse(c) :
+    if c == "B" :
+        return "W"
+    else :
+        return "B"
+
+def count(text) :
+    result = 100000000
+    for i in range(r-7) :
+        for j in range(c-7) :
+            cnt = 0
+            chess = [row[j:j+8] for row in arr[i:i+8]]
+            for R in range(8) :
+                text = reverse(text)
+                for C in range(8) :
+                    if chess[R][C] != text :
+                        cnt += 1
+                    text = reverse(text)
+            result = min(result, cnt)
+    return result
+
+print(min(count(reverse(arr[0][0])), count(arr[0][0])))

--- a/민장규/1주차/[BOJ] 9663.py
+++ b/민장규/1주차/[BOJ] 9663.py
@@ -1,0 +1,30 @@
+N = int(input())
+queen = [[i, -1] for i in range(N)]
+result = 0
+
+def Nqueen(r) :
+    global result
+    
+    if r == N :
+        result += 1
+        return
+    
+    for i in range(N) :
+        queen[r][1] = i
+        if findindex(r) :
+            Nqueen(r+1)
+
+def left(i, j) :
+    return i + j
+
+def right(i, j) :
+    return i + (N-1)-j
+
+def findindex(row) :
+    for i in range(row) :
+        if queen[row][1] == queen[i][1] or left(row, queen[row][1]) == left(queen[i][0], queen[i][1]) or right(row, queen[row][1]) == right(queen[i][0], queen[i][1]) :
+            return False
+    return True
+    
+Nqueen(0)
+print(result)

--- a/민장규/1주차/[PRGMS] 42842.py
+++ b/민장규/1주차/[PRGMS] 42842.py
@@ -1,0 +1,6 @@
+def solution(brown, yellow):
+    r, c = 1, 1
+    while not(r * c == brown + yellow and (r * 2) + ((c - 2) * 2) == brown) :
+        c += 1
+        r = (brown + yellow) // c
+    return [r, c]


### PR DESCRIPTION
# 문제 풀이 / 알고리즘 분류

- [BOJ] 1018

  - 모든 경우의 수를 고려하여 해결한 문제
  - 주어진 체스판의 크기에 따라 (7-M) * (7-N) 개 만큼 각각의 체스판을 2차원 리스트로 생성
  - 각 2차원 리스트에 대해 W로 시작하는 경우, B로 시작하는 경우에 따라 몇 개의 색을 변경해야 하는 지 구함
  - 구해진 모든 값에 대한 min 값을 result 값으로 출력

- [BOJ] 9663

  - 브루트포스 + 백트래킹 .. 정말 .. 정말 .. 오래 걸렸던 문제
  - 처음에는 Nqueen이라는 함수를 재귀적으로 호출할 생각을 못 함
    - 가장 헤맸던 부분
    - 1행에서 퀸 하나 배치 -> 2행에서 퀸 하나 배치 -> 3행에 퀸 둘 곳이 없으면 2행으로 돌아감
    - 위와 같은 로직을 짜는 데 상당히 애먹었던 문제
    - 처음에 접근했던 방법은 다음과 같음
     - 1행에 퀸 하나 배치 -> 그 때 2행에 퀸을 둘 수 있는 칸을 모두 리스트에 저장 -> 리스트를 돌며 3행에서도 비슷하게 반복
     - 로직 자체도 난해하고 구현하기도 너무 어려워서 포기
     - 중요한 건 굳이 각 index를 저장할 필요 없이 해당 행에 퀸을 둘 수 있냐 없냐 ? 이거였음
     - 해당 행에 퀸을 둘 수 있다면 재귀적으로 Nqueen함수 호출 
     - 쉽게 이런 생각을 하지 못했던 이유가, 그동안 풀었던 문제는 시간제한이 1초 내지 2초이다 보니 연산 횟수가 대략적으로 감이 잡혔는데, 일단 Nqueen함수 호출도 재귀적으로 많이 하면서 백트래킹도 더해지기에 연산 횟수가 어느 정도일지 대략적으로도 감이 잡히지 않아서 그런 듯
  - 대각선끼리 같은 건 어떻게 구할까 ? 
    - 퀸이 있는 위치의 행과 열을 알아야 대각선 상 어디 있는 지 알 수 있기에 queen 리스트에 퀸이 있는 행과 열의 정보를 모두 받았음
    - 사실 행의 정보는 굳이 필요하진 않았을 듯.. 하지만 눈치 채고 나선 너무 늦었었음
    - 행과 열을 더하여 (만약 2행 2열이면 2+2 = 4) 대각선으로 동일한 지 확인하였는데 이걸 좀 비효율적으로 찾은 거 같음
    - 결국 pypy3으로도 시간초과. 대각선 상으로 동일한 지 보다 빠르게 찾아낼 수 있는 방법이 있어야 할 듯

- [PRGMS] 42842

  - 비교적 쉬웠던 문제
  - 가로 * 세로 == (brown 블럭과 yellow 블럭의 수의 합) / (가로 * 2) + ((세로 - 2) * 2) == brown 블럭
    - 위의 조건을 만족시킬 때까지 반복문 수행
  - 문제의 조건 상 세로의 크기가 더 작거나 같으므로 세로의 크기를 1부터 하나씩 증가시키기
    - 코드에는 c를 하나씩 증가시키는 걸로 되어있는데 엄밀히는 행의 길이인 r을 1부터 하나씩 늘리고 return 값으로 [c, r] 을 해주는 게 맞는 거 같습니다 !

# 이슈 & 질문
- 엔퀸 대각선 상으로 동일한 조건을 모르겠습니다
