### PR TITLE
[2주차] / 윤창섭

### DIFF
--- a/윤창섭/2주차/[BOJ] 2636.py
+++ b/윤창섭/2주차/[BOJ] 2636.py
@@ -1,0 +1,114 @@
+import sys
+from collections import deque
+
+sys.setrecursionlimit(10**6)
+
+
+class Cheese:
+    def __init__(self, r, c):
+        self.r = r
+        self.c = c
+        self.board = [list(map(int, input().split())) for i in range(r)]
+        self.visited = [[False] * c for i in range(r)]
+        self.dy = [-1, 0, 1, 0]
+        self.dx = [0, 1, 0, -1]
+
+    def reset_visited(self):
+        self.visited = [[False] * self.c for i in range(self.r)]
+
+    def cheese_empty(self):
+        return all(cell == 0 for r in self.board for cell in r)
+
+    def find_cheese(self):
+        return sum(1 for r in self.board for cell in r if cell == 1)
+
+    def dfs(self, sy, sx):
+        if self.board[sy][sx] == 1:
+            self.board[sy][sx] = 0
+            return
+
+        for i in range(4):
+            ny, nx = sy + self.dy[i], sx + self.dx[i]
+            if ny < 0 or nx < 0 or ny >= self.r or nx >= self.c or self.visited[ny][nx]:
+                continue
+            self.visited[ny][nx] = True
+            self.dfs(ny, nx)
+        return
+
+    def bfs(self, sy, sx):
+        queue = deque()
+        queue.append([sy, sx])
+        self.visited[sy][sx] = True
+
+        while queue:
+            y, x = queue.popleft()
+
+            if self.board[y][x] == 1:
+                self.board[y][x] = 0
+                continue
+
+            for i in range(4):
+                ny, nx = y + self.dy[i], x + self.dx[i]
+
+                if (
+                    ny < 0
+                    or nx < 0
+                    or ny >= self.r
+                    or nx >= self.c
+                    or self.visited[ny][nx]
+                ):
+                    continue
+                self.visited[ny][nx] = True
+                queue.append([ny, nx])
+
+    def solve_dfs(self):
+        time = 0
+        cheese_counts = []
+
+        while True:
+            self.reset_visited()
+            tmp = self.find_cheese()
+            self.dfs(0, 0)
+            cheese_counts.append(self.find_cheese())
+            time += 1
+            if self.cheese_empty():
+                cheese_counts.pop()
+                break
+        return time, cheese_counts[-1] if cheese_counts else tmp
+
+    def solve_bfs(self):
+        time = 0
+        cheese_counts = []
+
+        while True:
+            self.reset_visited()
+            tmp = self.find_cheese()
+            self.bfs(0, 0)
+            cheese_counts.append(self.find_cheese())
+            time += 1
+            if self.cheese_empty():
+                cheese_counts.pop()
+                break
+        return time, cheese_counts[-1] if cheese_counts else tmp
+
+
+def main():
+    r, c = map(int, input().split())
+    board = Cheese(r, c)
+    time, cnt = board.solve_bfs()
+    print(time, cnt)
+
+
+main()
+
+"""
+함수형으로 풀어본 뒤 해당 로직을 클래스형으로 다시 풀어봤다
+
+우선 dfs와 bfs 모두 사용했다.
+
+dfs는 재귀를 사용했고, bfs는 deque를 사용했다.
+dfs의 경우 108ms, bfs의 경우 92ms가 걸렸다
+
+또한 dfs를 사용할 경우, 함수형으로 풀었을 때는 112ms, 클래스형으로 풀었을 때는 108ms가 걸렸고, 코드길이 또한 짧아졌다
+
+"""

--- a/윤창섭/2주차/[BOJ] 3187.py
+++ b/윤창섭/2주차/[BOJ] 3187.py
@@ -1,0 +1,111 @@
+import sys
+from collections import deque
+
+sys.setrecursionlimit(10**6)
+
+r, c = map(int, input().split())
+board = [list(input()) for i in range(r)]
+
+dy = [-1, 0, 1, 0]
+dx = [0, 1, 0, -1]
+
+
+q = deque()
+
+visited = [[False] * c for i in range(r)]
+sheep = 0
+sheeps = 0
+wolf = 0
+wolves = 0
+
+for i in range(r):
+    for j in range(c):
+        if board[i][j] == "v":
+            wolves += 1
+        elif board[i][j] == "k":
+            sheeps += 1
+
+
+def dfs(sy, sx):
+    global wolf, sheep
+    visited[sy][sx] = True
+    if board[sy][sx] == "v":
+        wolf += 1
+    elif board[sy][sx] == "k":
+        sheep += 1
+
+    for i in range(4):
+        ny, nx = sy + dy[i], sx + dx[i]
+
+        if (
+            ny < 0
+            or nx < 0
+            or ny >= r
+            or nx >= c
+            or visited[ny][nx]
+            or board[ny][nx] == "#"
+        ):
+            continue
+        dfs(ny, nx)
+
+
+def bfs(sy, sx):
+    global wolf, sheep
+    q.append([sy, sx])
+    visited[sy][sx] = True
+    while q:
+        y, x = q.popleft()
+        if board[y][x] == "v":
+            wolf += 1
+        elif board[y][x] == "k":
+            sheep += 1
+
+        for i in range(4):
+            ny, nx = y + dy[i], x + dx[i]
+            if (
+                ny < 0
+                or nx < 0
+                or ny >= r
+                or nx >= c
+                or visited[ny][nx]
+                or board[ny][nx] == "#"
+            ):
+                continue
+            visited[ny][nx] = True
+            q.append([ny, nx])
+
+
+for i in range(r):
+    for j in range(c):
+        if board[i][j] != "#" and not visited[i][j]:
+            wolf = 0
+            sheep = 0
+            bfs(i, j)
+            if sheep > wolf:
+                wolves -= wolf
+            else:
+                sheeps -= sheep
+
+
+print(sheeps, wolves)
+
+"""
+양 > 늑대 일 경우 양은 늑대를 잡아먹고, 살아남는다.
+양 <= 늑대일 경우 양을 모두 잡아먹힌다.
+
+모든 양과 늑대의 수를 순회를 통해 탐색한다.
+
+벽이 아니고, 방문한 곳이 아닌 점에 대해서 탐색을 시작한다.
+
+dfs의 경우 재귀를 사용하여 울타리에 갇힌 양과 늑대의 수를 구한다.
+이후 조건에 맞게 양과 늑대의 수를 빼준다.
+
+bfs의 경우 queue를 사용하여 울타리에 갇힌 양과 늑대의 수를 구한다.
+이때, python에서는 queue 대신 list를 사용하는데 이는 시간초과를 발생시킨다.
+따라서 deque를 사용하여 queue를 구현한다.
+deque의 popleft() 함수를 사용하여 일반 queue와 같은 기능을 수행하도록 한다.
+이후 로직은 dfs를 사용할 경우와 동일하다
+
+dfs를 사용한 경우 시간은 176ms이고, bfs를 사용한 경우 시간은 136ms이다.
+bfs가 시간적인 면에서 더 유리하다고 할 수 있다.
+"""

--- a/윤창섭/2주차/[PRGMS] 49189.py
+++ b/윤창섭/2주차/[PRGMS] 49189.py
@@ -1,0 +1,36 @@
+from collections import deque
+
+
+def bfs(graph, root):
+    visited = {node: -1 for node in graph}  # Graph의 모든 node에 대해 depth를 -1로 초기화
+    queue = deque([(root, 0)])  # Deque: [node, depth]
+
+    while queue:
+        current_node, depth = queue.popleft()
+        if visited[current_node] == -1:  # 방문하지 않은 점에 대해
+            visited[current_node] = depth  # 현재 깊이를 저장
+            for neighbor in graph[current_node]:  # 현재 노드의 다음 노드에 대해
+                if visited[neighbor] == -1:  # 방문하지 않았다면
+                    queue.append((neighbor, depth + 1))  # 깊이를 늘려 방문
+
+    return visited
+
+
+def solution(n, edge):
+    graph = dict()
+    for a, b in edge:  # 주어진 리스트를 dict형태로 변환 -> graph 형태로 나타낼 수 있음
+        graph.setdefault(a, []).append(b)
+        graph.setdefault(b, []).append(a)
+
+    depths = bfs(graph, 1)
+    max_depth = max(depths.values())
+
+    return list(depths.values()).count(max_depth)
+
+
+"""
+깊이를 구하여, 가장 큰 깊이가 몇 개 존재하는 지 구하면 되는 문제
+처음에 dfs를 쓰려고 했지만, dfs를 쓸 경우 레벨별 탐색이 가능하지 않아 bfs를 사용하여 해결
+dfs의 경우 한 방향으로만 탐색을 하기 때문에, 레벨별 탐색이 불가능함
+bfs의 경우 시작 정점으로부터 가까운 노드부터 탐색함. 즉, 레벨별 탐색이 가능함
+"""


### PR DESCRIPTION
# 문제 풀이 / 알고리즘 분류

- [BOJ] 3187 양치기 꿍
  - python으로 처음 dfs를 풀어본 문제
  - python에서는 재귀함수의 깊이를 1,000번으로 제한하기 때문에 기본적으로 대부분의 문제에서 dfs 알고리즘을 통해 해결한다면 제한에 걸릴 가능성이 존재한다. 따라서 sys 모듈에서 최대 재귀 깊이를 수동으로 지정하여 해결한다.
  - 맵 전체를 순회하여 모든 양과 늑대의 수를 저장한 뒤, dfs 혹은 bfs를 통해 각 울타리 내의 양과 늑대의 수를 탐색하여, 둘을 비교 후 조건에 맞게양 혹은 늑대의 전체 수에서 제거한다.
  - dfs의 경우 재귀를 사용하기 때문에, 재귀의 깊이가 깊어질수록 시간이 오래걸린다. 따라서 시간초과가 발생한다면 로직 자체를 bfs로 바꿔도 괜찮을 듯 하다.

- [BOJ] 2636 치즈
  - 내부의 공간에 대해서는 생각하지 않아도 되는 문제이다. 우선 무한루프를 통해 주어진 맵에 대해 탐색을 시작한다. 문제의 조건에 대해 1시간당 바깥 공기와 접촉한 치즈는 녹는다. 이때, 결과값으로 치즈가 모두 녹는데 걸린 시간과, 다 녹기 직전의 치즈가 몇 칸인지 반환해야 한다. 시간의 경우 while문을 돌아가며 반복한 횟수로 저장할 수 있지만, 다 녹기 직전 치즈가 몇칸에 존재하는지는 구하기 까다로웠다. 이전에 c++을 통해 해결했을 때는, dfs혹은 bfs에서 빠져나오고, 이후 존재하는 치즈를 vector에 입력하여 해당 vector로 치즈가 몇 개 남아있는지 판단했지만, python에서 vector의 형태로 나타내기가 쉽지 않고, 따로 생각하기 싫어 dfs 혹은 bfs를 수행한 후 남은 치즈의 수를 list에 저장했다.
  - 계속 95%에서 index error가 발생하여 어떤 반례인지 찾던 중 1시간만에 모든 치즈가 녹을 때에 대해 list에 값이 존재하지 않아 index error가 발생했다. 따라서 tmp라는 변수에 dfs 혹은 bfs를 하기 전 치즈의 수를 저장하고, list의 크기가 0인 경우 해당 tmp변수의 값을 사용하도록 하여 해결했다.
  - bfs와 dfs 둘 다 적용하여 해결하고 싶어서, 테스트에 편하게 함수형으로 코드를 작성했는데 너무 지저분해보였다. 그래서 class형으로 변경하여 제출한다.

- [PRGMS] 49189 가장 먼 노드
  - 최초 dfs를 통해 재귀의 깊이를 반환하면 괜찮지 않을까 생각하여 dfs로 문제를 해결하기 시작했다. 그러나 모든 노드에 대해 깊이,즉 레벨을 탐색해야하는 문제이고, dfs의 경우 레벨별 탐색이 가능하지 않기 때문에 bfs를 통해 문제를 해결했다.
  - 노드간의 간선이 list로 주어지고, 각 노드별 연관관계를 그래프로 나타내기 위해 list를 dictionary로 변환하여 문제를 해결했다.
  - bfs를 통해 각 노드별 깊이(레벨)을 탐색하고, 해당 결과에 대해 max value의 값을 구한 뒤, 해당 값을 가진 노드가 몇 개인지 계산했다.

# 이슈 & 질문

@tkdwns414 @minwoo0419 @dlawjddn @cho1n  @Jang99u 