### PR TITLE
[2주차] / [조민우]

### DIFF
--- a/조민우/2주차/[BOJ] 2636.py
+++ b/조민우/2주차/[BOJ] 2636.py
@@ -1,0 +1,29 @@
+n, m = map(int, input().split())
+cheese = [list(map(int, input().split())) for i in range(n)]
+visit = [list(0 for i in range(m)) for i in range(n)]
+melt = [(0,0)]
+dx = [1, -1, 0, 0]
+dy = [0, 0, 1, -1]
+
+def bfs(melt, time):
+    count = len(melt)
+    find = []
+    while melt:
+        x, y = melt.pop(0)
+        for i in range(4):
+            nx, ny = x + dx[i], y + dy[i]
+            if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
+                if visit[nx][ny] == 0:
+                    visit[nx][ny] = 1
+                    if cheese[nx][ny] == 0: #공기일 경우
+                        melt.append((nx, ny))   #현재 큐에 추가해서 bfs
+                    elif cheese[nx][ny] == 1:   #공기와 인접한 치즈일 경우
+                        find.append((nx, ny))   #다음 함수에서 사용하기 위해 다음 큐(find)에 추가 @@현재 큐에 넣으면 공기에 안 닿는 치즈도 탐색할 수 있으므로
+    if find:
+        return bfs(find, time + 1)  #공기에 닫는 치즈로 bfs
+    else:
+        return time, count
+visit[0][0] = 1
+time, count = bfs(melt, 0)
+print(time)
+print(count)

--- a/조민우/2주차/[BOJ] 2636.py
+++ b/조민우/2주차/[BOJ] 2636.py
@@ -1,29 +1,73 @@
 n, m = map(int, input().split())
 cheese = [list(map(int, input().split())) for i in range(n)]
-visit = [list(0 for i in range(m)) for i in range(n)]
-melt = [(0,0)]
+melt = [list(0 for i in range(m)) for i in range(n)]
 dx = [1, -1, 0, 0]
 dy = [0, 0, 1, -1]
+day = 0
 
-def bfs(melt, time):
-    count = len(melt)
-    find = []
-    while melt:
-        x, y = melt.pop(0)
+def isFinish():
+    for i in cheese:
+        if i.count(1) != 0:
+            return 1
+    return 0
+
+def check(a, b):
+    for i in range(4):
+        nx = a + dx[i]
+        ny = b + dy[i]
+        if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
+            if cheese[nx][ny] < 0:
+                return 1
+    return 0
+
+def bfs(a, b):
+    global day
+    queue = [[a, b]]
+    visit[a][b] = 1
+    find.append([a,b])
+    while(queue):
+        x = queue[0][0]
+        y = queue[0][1]
+        queue.pop(0)
         for i in range(4):
-            nx, ny = x + dx[i], y + dy[i]
+            nx = x + dx[i]
+            ny = y + dy[i]
             if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
-                if visit[nx][ny] == 0:
+                if cheese[nx][ny] == 1 and visit[nx][ny] == 0:
+                    if check(nx, ny):
+                        find.append([nx,ny])
                     visit[nx][ny] = 1
-                    if cheese[nx][ny] == 0: #공기일 경우
-                        melt.append((nx, ny))   #현재 큐에 추가해서 bfs
-                    elif cheese[nx][ny] == 1:   #공기와 인접한 치즈일 경우
-                        find.append((nx, ny))   #다음 함수에서 사용하기 위해 다음 큐(find)에 추가 @@현재 큐에 넣으면 공기에 안 닿는 치즈도 탐색할 수 있으므로
-    if find:
-        return bfs(find, time + 1)  #공기에 닫는 치즈로 bfs
-    else:
-        return time, count
-visit[0][0] = 1
-time, count = bfs(melt, 0)
-print(time)
+                    queue.append([nx,ny])
+
+def findAir():
+    global day
+    queue = [[0, 0]]
+    while(queue):
+        x = queue[0][0]
+        y = queue[0][1]
+        queue.pop(0)
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
+                if cheese[nx][ny] <= 0 and cheese[nx][ny] != -day:
+                    cheese[nx][ny] = -day
+                    queue.append([nx,ny])
+
+while(isFinish()):
+    visit = [list(0 for i in range(m)) for i in range(n)]
+    find = []
+    day += 1
+    findAir()
+    for i in range(n):
+        for j in range(m):
+            if cheese[i][j] == 1 and visit[i][j] == 0:
+                bfs(i, j)
+    for i in find:
+        melt[i[0]][i[1]] = day
+        cheese[i[0]][i[1]] = 0
+print(day)
+count = 0
+for i in melt:
+    count += i.count(day)
 print(count)

--- a/조민우/2주차/[BOJ] 3187.py
+++ b/조민우/2주차/[BOJ] 3187.py
@@ -1,0 +1,62 @@
+import sys
+sys.setrecursionlimit(10**6) #재귀 최대 깊이 수정
+
+n, m = map(int, input().split())
+field = [list(input()) for i in range(n)]
+visit = [list(0 for i in range(m)) for i in range(n)]
+dx = [1, -1, 0, 0]
+dy = [0, 0, 1, -1]
+
+def bfs(a, b):
+    queue = [[a, b]]
+    visit[a][b] = 1
+    sheep, wolf = 0, 0
+    if field[a][b] == 'v':
+        wolf += 1
+    elif field[a][b] == 'k':
+        sheep += 1              #처음 인덱스 확인
+    while(queue):
+        x, y = queue[0][0], queue[0][1]
+        queue.pop(0)
+        for i in range(4):
+            nx, ny = x + dx[i], y + dy[i]
+            if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
+                if field[nx][ny] != '#' and visit[nx][ny] == 0:
+                    if field[nx][ny] == 'v':
+                        wolf += 1
+                    elif field[nx][ny] == 'k':
+                        sheep += 1
+                    visit[nx][ny] = 1
+                    queue.append([nx, ny])
+    if wolf >= sheep:
+        return 0, wolf
+    else:
+        return sheep, 0
+
+def dfs(a, b):
+    visit[a][b] = 1
+    global s, w
+    if field[a][b] == 'v':
+        w += 1
+    elif field[a][b] == 'k':
+        s += 1              #처음 인덱스 확인
+    for i in range(4):
+        nx, ny = a + dx[i], b + dy[i]
+        if (nx >= 0 and nx < n) and (ny >= 0 and ny < m):
+            if field[nx][ny] != '#' and visit[nx][ny] == 0:
+                dfs(nx, ny)
+
+wolf, sheep = 0, 0
+for i in range(n):
+    for j in range(m):
+        if (visit[i][j] == 0 and field[i][j] != '#'):
+            s, w = 0, 0
+            # s, w = bfs(i, j)
+            # wolf += w
+            # sheep += s
+            dfs(i, j)
+            if w >= s:
+                wolf += w
+            else:
+                sheep += s
+print(sheep, wolf)

--- a/조민우/2주차/[PRGMS] 49189.py
+++ b/조민우/2주차/[PRGMS] 49189.py
@@ -1,0 +1,18 @@
+def solution(n, edge):
+    answer = 0
+    map = [[] for i in range(n+1)]
+    visit = [0 for i in range(n+1)]
+    for i in range(len(edge)):
+        map[edge[i][0]].append(edge[i][1])
+        map[edge[i][1]].append(edge[i][0])
+    queue = [1]
+    visit[1] = 1
+    while(queue):
+        x = queue[0]
+        queue.pop(0)
+        for i in map[x]:
+            if visit[i] == 0:
+                visit[i] = visit[x] + 1
+                queue.append(i)
+    answer = visit.count(max(visit))
+    return answer


### PR DESCRIPTION
# 문제 풀이 / 알고리즘 분류

- [BOJ] 2636
  - 한 시간 마다 공기에 접촉된 치즈가 녹을 때, 치즈가 전부 녹는 시간과 마지막에 남은 치즈 칸 수를 구하는 문제였다. 
  - 문제 접근(현재 코드)
    1. 치즈 안에 있는 공기는 진공상태이므로 그 칸과 닿아도 녹지 않기 때문에 무조건 0,0에서 바깥 공기를 bfs를 통해 체크
    2. 치즈들을 bfs를 통해 찾으며 바깥공기와 닿아있을 경우 녹이고 공기로 바꿈
    3. a, b를 반복하며 값을 찾아냄
  - 문제를 풀고 나서 다시 한번 생각을 해봤는데, 너무 비효율적이라고 생각이 들어 고민을 했다.
    - b번에서 치즈로 굳이 바깥치즈를 안찾아도 된다는 생각이 들었다.
    - 그럼 바깥공기로만 찾으면 되서 bfs를 한번만 돌려도 값이 나올거라는 생각이 들었다.
    - 새로운 문제 접근
      - 0,0부터 시작하여 바깥공기를 bfs를 통해 체크를 할 때, 그 공기와 맞닿은 치즈가 있는지 확인한다.
      - 치즈가 있을 경우 새로운 queue에 저장해 놓는다.
      - 바깥공기를 다 탐색했을 경우 바깥공기와 맞닿아있던 치즈를 저장해놓은 queue를 이용해 bfs를 재귀함수를 통해 찾는다.
      - 이렇게 하면 치즈 한 겹마다 재귀가 한번 씩 실행되어서 더욱 깔끔하고 적은 연산을 수행하게 된다.
      - 이렇게 푸니 처음 문제를 접근했을 때의 연산보다 절반이나 줄어들었다.

- [BOJ] 3187
  - 한 영역 마다 양과 늑대의 개수를 파악하고, 양이 많으면 늑대가 죽고, 그 외의 경우 양이 죽는데 최종적으로 살아남은 양과 늑대 마리 수를 구하는 전형적인 bfs, dfs를 사용하는 문제였다.
  - 문제 접근
    - bfs와 dfs를 통해 영역에 대해 전체 탐색만 하면 되므로 bfs를 쓰든, dfs를 쓰든 탐색만 잘 되면 되는 문제이다.
    - bfs나 dfs를 통해 영역에 대해 탐색을 해서 나온 양과 늑대 개수를 통해 결과를 도출하기만 하면 된다.

- [PRGMS] 49189
  - 1번 노드에서 가장 멀리 떨어진 노드 개수를 구하는 문제이다. 이 문제도 탐색만 잘 되면 어렵지 않은 문제이다.
  - 문제 접근
    - 양방향으로 연결된 노드들을 그래프를 통해 저장한다.
    - 순차적으로 연결된 그래프들을 탐색하며 가장 늦게 찾아진 노드의 개수만 구하면 된다.
    - dfs도 사용할 수는 있겠지만, 이런 유형의 문제는 dfs를 사용하면 visit의 값을 계속 비교해가며 최신화시켜줘야 하는 번거로움이 발생하기 때문에 bfs로 푸는 것을 추천한다
  - 예상 외로 연결된 노드들을 그래프에 저장할 때, n*n배열에 값을 넣으니까 시간초과가 나서, n*0배열을 만들어 놓고 해당 행과 연결된 노드들만 추가를 해줘서 시간초과문제를 해결할 수 있었다.

# 이슈 & 질문
- 2636 새로운 코드 궁금하시면 올려드리겠습니다
