### PR TITLE
[2주차] / [박상준]

### DIFF
--- a/박상준/week2/[BOJ] 2636.py
+++ b/박상준/week2/[BOJ] 2636.py
@@ -1,0 +1,46 @@
+from collections import deque
+
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+def bfs():
+    visited = [[0 for _ in range(m)] for _ in range(n)]
+    queue = deque([(0, 0)])
+    visited[0][0] = 1
+
+    while queue:
+        x, y = queue.popleft()
+        for i, j in zip(dx, dy):
+            if x + i < 0 or x + i >= n or y + j < 0 or y + j >= m:
+                continue
+            if graph[x + i][y + j] == 0 and visited[x + i][y + j] == 0:
+                queue.append((x + i, y + j))
+                visited[x + i][y + j] = 1
+            if graph[x + i][y + j] == 1:
+                visited[x + i][y + j] = 1
+                graph[x + i][y + j] = 0
+
+
+def remaining_cheese():
+    sum = 0
+    for i in range(n):            
+        sum += graph[i].count(1)
+    return sum
+
+
+n, m = map(int, input().split())
+graph = [list(map(int, input().split())) for _ in range(n)]
+
+hour = 0
+bf = 0
+while True:
+    hour += 1
+    bf = remaining_cheese()
+    bfs()
+    at = remaining_cheese()
+    if at == 0:
+        break
+    bf = at
+
+print(hour)
+print(bf)

--- a/박상준/week2/[BOJ] 3187.py
+++ b/박상준/week2/[BOJ] 3187.py
@@ -1,0 +1,69 @@
+from collections import deque
+# for dfs
+import sys
+sys.setrecursionlimit(10**6)
+
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+def bfs(x, y):
+    queue = deque([(x, y)])
+
+    wolf, sheep = 0, 0
+    while queue:
+        a, b = queue.popleft()
+        if a < 0 or a >= R or b < 0 or b >= C or visited[a][b] == 1 or graph[a][b] == '#':
+            continue
+        else:
+            if graph[a][b] == 'v':
+                wolf += 1
+            if graph[a][b] == 'k':
+                sheep += 1
+            visited[a][b] = 1
+            for i, j in zip(dx, dy):
+                queue.append((a + i, b + j))
+
+    if sheep > wolf:
+        return sheep, 0
+    else:
+        return 0, wolf
+
+
+def dfs(x, y):
+    global g_sheep, g_wolf
+    if x < 0 or x >= R or y < 0 or y >= C or visited[x][y] == 1 or graph[x][y] == '#':
+        return 0
+    if graph[x][y] == 'v':
+        g_wolf += 1
+    if graph[x][y] == 'k':
+        g_sheep += 1
+    visited[x][y] = 1
+    for i, j in zip(dx, dy):
+        dfs(x + i, y + j)
+
+
+R, C = map(int, input().split())
+graph = [input() for _ in range(R)]
+visited = [[0 for _ in range(C)] for _ in range(R)]
+t_sheep, t_wolf = 0, 0
+
+for i in range(R):
+    for j in range(C):
+        # bfs
+        if graph[i][j] != '#' and visited[i][j] == 0: # 벽이 아닌데 방문한 적 없으면
+            s, w = bfs(i, j) # 해당 구역에서 살아남은 양, 늑대 수 반환_bfs
+            visited[i][j] = 1
+            t_sheep += s
+            t_wolf += w
+
+        # dfs
+        # g_sheep, g_wolf = 0, 0
+        # if graph[i][j] != '#' and visited[i][j] == 0: # 벽이 아닌데 방문한 적 없으면
+        #     dfs(i, j)
+        #     if g_sheep > g_wolf:
+        #         t_sheep += g_sheep
+        #     else:
+        #         t_wolf += g_wolf
+
+print(t_sheep, t_wolf)
+

--- a/박상준/week2/[PRGMS]  49189.py
+++ b/박상준/week2/[PRGMS]  49189.py
@@ -1,0 +1,24 @@
+from collections import deque
+
+
+def solution(n, edge):
+    v_map = [[]for _ in range(n)]
+    
+    for item in edge: # 맵 만들기
+        v_map[item[0] - 1].append(item[1] - 1)
+        v_map[item[1] - 1].append(item[0] - 1)
+        
+    visited = [999 for _ in range(n)]
+    visited[0] = 0 # 본인까지의 cost는 0
+    queue = deque()
+    queue.append(0) 
+        
+    while queue:
+        current_v = queue.popleft()
+        for v in v_map[current_v]:
+            if visited[v] == 999 or visited[v] > visited[current_v] + 1:
+                visited[v] = visited[current_v] + 1
+                queue.append(v)
+        
+    answer = visited.count(max(visited))
+    return answer


### PR DESCRIPTION
# 문제 풀이 / 알고리즘 분류

- [PRGMS] 49189
 문제 자체는 어렵지 않았습니다. 일반적인 각 정점까지의 최단거리를 구하는 bfs를 이용하여 최단거리를 구한 후 최단거리가 가장 긴 정점의 개수들을 출력하면 되는 문제입니다. 다만 **문제를 제대로 읽지 않아서** 들어오는 edge값이 그냥 간선 맵이라고 판단 후 진행하였고 그 사실을 좀 나중에 출력문으로 디버깅해보면서 알게돼서... 생각보다 시간을 잡아먹었습니다. **문제 잘 읽읍시다!**

추가적으로 19번째 줄의 조건문에  visited[v] == 999를 넣기 전에는 8번 테스트에서 실패했었는데 (방문한 적이 없어서 999였으면 애초에 무조건 업데이트 될거라 생각했기에) 해당 조건을 넣으니까 성공했습니다. 정황 상 한 번도 방문하지 않은 곳은 무조건 방문하게 수정해준건데 반례가 뭐인지는 모르겠네요. 그리고 이제와서 보니 visited보다는 cost라는 이름이 더 정확했을 것 같습니다.

- [BOJ] 3187
 dfs로 푸는 방법과 bfs로 푸는 방법 모두 있는 문제입니다. 간단하게 설명하자면 플로우는 다음과 같습니다.
 1. 전체 맵을 0,0부터 순회합니다.
 2. 벽이 아닌 곳(방문할 수 있는 곳)인데 방문한 적이 없으면 방문합니다.
 3. 방문 후 상하좌우를 탐색하며 해당 구역의 양과 늑대 수를 파악합니다.
 4. 파악한 양과 늑대의 수를 이용해 누가 이겼는지 확인 후 살아남은 양, 늑대 수에 알맞게 더해줍니다.
 5. 한 번 확인하면 해당 구역은 모두 확인 완료됐습니다.

 여기서 다른 dfs와 bfs가 다른 점이 나오는데 동물들의 수를 파악하는 방법이 다릅니다.
 bfs의 경우에는 재귀를 사용하지 않고 해당 구역의 모든 곳을 큐를 이용하여 방문하기 때문에 따로 정의한 bfs 함수 내부에서 해당 구역의 양과 늑대 수를 확인할 수 있습니다.
 반면 dfs는 재귀를 사용하며 한 번에 구역 하나를 확인하기는 하지만 해당 구역을 확인하는 방법이 셀 하나하나를 기준으로 확인하기 때문에 늑대와 양의 수를 파악하기 위해서는 그 외부에서 늑대와 양의 수를 의미하는 변수를 만들어줄 필요가 있습니다. (재귀를 하면서도 유지하기 위해서)
 
 해당 문제는 위에 말한 차이점에 있어서 bfs를 먼저 하고 후에 dfs를 하려하니... bfs 관련 코드를 주석을 최대한 안하고 하려했더니 조금 힘들게 했던 것 같습니다.

- [BOJ] 2636
1. 시간마다 방문했는지를 표기할 visited라는 맵을 하나 만들어줍니다.
2. 0,0 부터 시작해서 공기이면서 방문한 적이 없으면 큐에 추가합니다.
3. 치즈를 만나면 해당 부분을 공기로 바꾸고 이번에 방문한 적이 있다고 표기합니다.

위 과정을 반복하면 내부에 있는 구멍있는 치즈에는 영향을 주지 않으며 가장 바깥쪽의 치즈만 녹일 수(공기로 바꿀 수) 있습니다. 제출할 때 여러번 틀렸는데 첫번째는 큐에 추가할 때 visited를 업데이트해주지 않아서 중복된 셀이 너무 많이 들어와서이고 두번째는 1시간만에 다 녹아버리는 치즈에 대해서는 마지막 치즈 수가 몇이었는지 못 세는 코드를 짜놓았기 때문입니다. 두번째 틀린 부분 찾느라 시간을 상당히 많이 썼습니다.

찾은 반례 (1\n6이 나와야 하는데 1\n0이 나오고 있었음)
5 5
0 0 0 0 0
0 1 1 0 0
0 1 0 1 0
0 1 1 1 0
0 0 0 0 0

# 이슈 & 질문
@kurtyoon @minwoo0419 @dlawjddn @cho1n @Jang99u 
